### PR TITLE
Add adjustable light treatment price

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Tento repozitář obsahuje jednoduchý GUI nástroj **Generátor lékařské zprávy - Doctor-11** postavený na knihovně PySide6. Aplikace umožňuje vyplnit základní sekce lékařské zprávy, dopočítá celkovou cenu a výsledek uloží do schránky.
 
+Od verze 2 aplikace obsahuje spinner pro volbu ceny lehkého ošetření.
+Hodnota lze nastavit v rozmezí 1000–1500 Kč, výchozí cena je 1250 Kč.
+
 ## Požadavky
 - Python 3.10+
 - PySide6

--- a/doctor11_gui.py
+++ b/doctor11_gui.py
@@ -1,5 +1,5 @@
 import sys
-from PySide6 import QtWidgets, QtGui
+from PySide6 import QtWidgets, QtGui, QtCore
 
 SECTIONS = ["OA", "RA", "PA", "SA", "FA", "AA", "EA", "NO", "VF", "Subj.", "Obj.", "Vyšetření", "Terapie"]
 
@@ -12,6 +12,12 @@ LOCALITY_PRICES = {
 
 HEAVY_TREATMENT_EXTRA = 150
 BASE_PRICE = 500
+# Default price for light treatment. The recommended range is
+# 1000–1500 Kč. A spin box in the UI allows choosing a value
+# within this range and falls back to this default if unchanged.
+TREATMENT_LIGHT_MIN = 1000
+TREATMENT_LIGHT_MAX = 1500
+TREATMENT_LIGHT = 1250
 
 class ReportGenerator(QtWidgets.QWidget):
     def __init__(self):
@@ -34,6 +40,10 @@ class ReportGenerator(QtWidgets.QWidget):
         self.locality_combo = QtWidgets.QComboBox()
         self.locality_combo.addItems(list(LOCALITY_PRICES.keys()))
         form.addRow("Lokalita:", self.locality_combo)
+        self.treatment_spin = QtWidgets.QSpinBox()
+        self.treatment_spin.setRange(TREATMENT_LIGHT_MIN, TREATMENT_LIGHT_MAX)
+        self.treatment_spin.setValue(TREATMENT_LIGHT)
+        form.addRow("Cena lehkého ošetření:", self.treatment_spin)
         self.heavy_check = QtWidgets.QCheckBox("Těžší ošetření (včetně bezvědomí)")
         form.addRow(self.heavy_check)
         layout.addLayout(form)
@@ -78,7 +88,11 @@ class ReportGenerator(QtWidgets.QWidget):
         report += "\n\n" + "MUDr. asistent – Fero Lakatos, Doctor-11 | Odznak: 97-5799"
         self.result_box.setPlainText(report)
         QtGui.QGuiApplication.clipboard().setText(report)
-        price = BASE_PRICE + LOCALITY_PRICES[self.locality_combo.currentText()]
+        price = (
+            BASE_PRICE
+            + self.treatment_spin.value()
+            + LOCALITY_PRICES[self.locality_combo.currentText()]
+        )
         if self.heavy_check.isChecked():
             price += HEAVY_TREATMENT_EXTRA
         self.price_label.setText(f"Cena: {price} Kč")


### PR DESCRIPTION
## Summary
- add constant describing allowed range for light treatment
- allow user to choose light treatment price via a spin box
- include chosen price in final cost computation
- mention new spinner in README

## Testing
- `python -m py_compile doctor11_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68664c161aec832193ffd4e1af6dad7d