### PR TITLE
Implement online MKN‑10 lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Tento repozitář obsahuje jednoduchý GUI nástroj **Generátor lékařské zpr
 
 ## Požadavky
 - Python 3.10+
-- PySide6
+ - PySide6
+ - requests
 
 ## Spuštění
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PySide6==6.7.0
+requests


### PR DESCRIPTION
## Summary
- implement `fetch_mkn10_online` using a GitHub-hosted ICD-10 dataset
- show fetched diagnosis in GUI
- add requests to requirements
- mention requests in README

## Testing
- `python -m py_compile doctor11_gui.py`
- `python - <<'EOF'
from doctor11_gui import fetch_mkn10_online
print('Result:', fetch_mkn10_online('A00'))
EOF` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68664c1436f8832189168f6bf3436bb1