### PR TITLE
Add default anamnesis texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Tento repozitář obsahuje GUI nástroj **Generátor lékařské zprávy – Doctor‑11** postavený na knihovně PySide6. Formulář je rozdělen do několika skupin (anamnéza, status praesens, vyšetření, diagnóza a výstup). Aplikace automaticky dopočítá cenu zásahu podle zadaných parametrů a vygeneruje profesionální záznam připravený ke kopírování či uložení do TXT souboru.
 Diagnózy MKN‑10 jsou načítány z lokálního JSON souboru `data/diagnosis_children.json`, takže aplikace funguje i bez internetu.
 
+Při generování zprávy se navíc automaticky doplní výchozí texty do prázdných polí anamnézy, takže výstup je vždy formálně kompletní.
+
 Po spuštění lze vzhled přepnout pomocí políčka **Tmavý režim**, které okamžitě změní barevné schéma.
 
 Krátká ukázka výsledného formátu zprávy:
@@ -16,8 +18,8 @@ Krátká ukázka výsledného formátu zprávy:
 **ZÁZNAM DO DOKUMENTACE**
 
 **Anamnéza**:
-OA: ...
-PA: ...
+OA: Bez závažné osobní anamnézy.
+PA: Pracovní anamnéza nevýznamná.
 
 **Vyšetření**: ...
 **Terapie**: ...

--- a/main.py
+++ b/main.py
@@ -11,6 +11,17 @@ import report_generator
 import theme
 
 ANAM_SECTIONS = ["OA", "RA", "PA", "SA", "FA", "AA", "EA", "NO"]
+# default texts for anamnesis sections if left empty by the user
+ANAM_DEFAULTS = {
+    "OA": "Bez závažné osobní anamnézy.",
+    "RA": "Rodinná anamnéza bez významných odchylek.",
+    "PA": "Pracovní anamnéza nevýznamná.",
+    "SA": "Sociální anamnéza standardní.",
+    "FA": "Dlouhodobě bez pravidelné medikace.",
+    "AA": "Bez známé alergie.",
+    "EA": "Epidemiologická anamnéza negativní.",
+    "NO": "Bez aktuálních potíží.",
+}
 STATUS_SECTIONS = ["VF", "Subj.", "Obj."]
 EXAM_SECTIONS = ["Vyšetření", "Terapie"]
 
@@ -398,7 +409,10 @@ class ReportGenerator(QtWidgets.QTabWidget):
         price = self.update_price()
         tags = self.generate_tags(mkn, diag, locality)
 
-        anam = {sec: self.fields[sec].toPlainText().strip() or "..." for sec in ANAM_SECTIONS}
+        anam = {
+            sec: self.fields[sec].toPlainText().strip() or ANAM_DEFAULTS[sec]
+            for sec in ANAM_SECTIONS
+        }
         status = {sec: self.fields[sec].toPlainText().strip() or "..." for sec in STATUS_SECTIONS}
         examination = self.fields[EXAM_SECTIONS[0]].toPlainText().strip() or "..."
         therapy = self.fields[EXAM_SECTIONS[1]].toPlainText().strip() or "..."


### PR DESCRIPTION
## Summary
- set up default messages for each anamnesis section
- insert those defaults when building a report
- update docs to mention the feature and show a short example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68665d8ce4ec8321a07f692201114d77