### PR TITLE
Add vital signs widgets and lab import

### DIFF
--- a/report_generator.py
+++ b/report_generator.py
@@ -18,6 +18,16 @@ def generate_report(data: dict) -> str:
     for key, text in data.get('status', {}).items():
         lines.append(f"{key}: {text or '...'}")
 
+    vitals = data.get('vitals')
+    if vitals:
+        lines.append("")
+        lines.append("__Vitální funkce__:")
+        for key, val in vitals.get('values', {}).items():
+            lines.append(f"{key}: {val}")
+        desc = vitals.get('desc')
+        if desc:
+            lines.append(desc)
+
     lines.append("")
     lines.append(f"**Vyšetření**: {data.get('examination') or '...'}")
     lines.append(f"**Terapie**: {data.get('therapy') or '...'}")


### PR DESCRIPTION
## Summary
- implement structured section for vital signs with validation and GCS calculator
- support suggestion for CMP in NO field and add health device checkboxes
- allow loading laboratory data from CSV or JSON
- output vital signs block in generated report

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68665e705f088321879db0639d79af48